### PR TITLE
Remove Duplicated @type Example

### DIFF
--- a/src/content/wiki/annotations.mdx
+++ b/src/content/wiki/annotations.mdx
@@ -1246,16 +1246,6 @@ local x
 </Accordion>
 
 <Accordion>
-<span slot="summary">Union Type Definition</span>
-
-```Lua
----@type boolean|number
-local x
-```
-
-</Accordion>
-
-<Accordion>
 <span slot="summary">Array Type Definition</span>
 
 ```Lua


### PR DESCRIPTION
Remove a duplicated union type definition example in the @type section