### PR TITLE
fix typo in _source_ annotation

### DIFF
--- a/src/content/wiki/annotations.mdx
+++ b/src/content/wiki/annotations.mdx
@@ -1181,7 +1181,7 @@ searching for the defintion of an item, its `@source` will be used instead.
 
 **Syntax**
 
-<div class="syntax">`@source <path>`</div>
+<div class="syntax">`---@source <path>`</div>
 
 **Examples**
 


### PR DESCRIPTION
Prefix is missed in   **@source** annotation syntax.