### PR TITLE
Fix CLI in diagnosis-report instructions

### DIFF
--- a/src/content/wiki/diagnosis-report.mdx
+++ b/src/content/wiki/diagnosis-report.mdx
@@ -11,7 +11,7 @@ You can use the [command line](/wiki/usage) to perform a diagnosis of your works
 
 The command should look like this:
 
-`lua-language-server --check E:\programming\myLuaProject --checklevel=warning`
+`lua-language-server --check E:\programming\myLuaProject --checklevel=Warning`
 
 {/* TODO: Update link to log file info */}
 The server will exit once the report is complete. The report will be written to `check.json` in your [logpath](https://github.com/LuaLS/lua-language-server/wiki/FAQ#where-can-i-find-the-log-file) (unless otherwise specified with [`--logpath`](/wiki/usage#--logpath)).


### PR DESCRIPTION
`Warning` has to be capitalized.