### PR TITLE
fix: remove one of the duplicated footer in wiki articles

### DIFF
--- a/src/layouts/WikiArticle.astro
+++ b/src/layouts/WikiArticle.astro
@@ -5,7 +5,6 @@ import Layout from "./Main.astro";
 import type { CollectionEntry } from "astro:content";
 import Icon from "~/components/common/Icon.astro";
 import Remark from "~/components/common/Remark.astro";
-import Footer from "~/components/layout/Footer.astro";
 import type { MarkdownHeading } from "astro";
 import path from "path";
 
@@ -88,7 +87,6 @@ export interface Props {
           </a>
         </div>
       </main>
-      <Footer />
     </div>
     <div id="outline" class="sidebar">
       <button class="open"><Icon name="list" group="solid" /></button>


### PR DESCRIPTION
Remove one of the duplicate Footers for the Main Layout has contained a footer.