### PR TITLE
--check usage tweaks

### DIFF
--- a/src/content/wiki/usage.mdx
+++ b/src/content/wiki/usage.mdx
@@ -129,8 +129,7 @@ line and immediately exit.
 
 **Type:** `string`
 
-Perform a "diagnosis report" where the results of the diagnosis are written to a
-file.
+Perform a "diagnosis report" where the results of the diagnosis are written to the [logpath](/wiki/faq/#where-can-i-find-the-log-file).
 
 Example: `--check=C:\Users\Me\path\to\workspace`
 

--- a/src/content/wiki/usage.mdx
+++ b/src/content/wiki/usage.mdx
@@ -127,10 +127,12 @@ line and immediately exit.
 
 ### --check
 
-**Type:** `boolean`
+**Type:** `string`
 
 Perform a "diagnosis report" where the results of the diagnosis are written to a
 file.
+
+Example: `--check=yes`
 
 ### --checklevel
 
@@ -145,6 +147,7 @@ file. Options include, in order of priority:
 - Error
 - Warning
 - Information
+- Hint
 
 Example: `--checklevel=Information`
 

--- a/src/content/wiki/usage.mdx
+++ b/src/content/wiki/usage.mdx
@@ -132,7 +132,7 @@ line and immediately exit.
 Perform a "diagnosis report" where the results of the diagnosis are written to a
 file.
 
-Example: `--check=yes`
+Example: `--check=C:\Users\Me\path\to\workspace`
 
 ### --checklevel
 


### PR DESCRIPTION
hello there.
- we are missing new `--checklevel` value: `Hint`
- `--check` is expecting a string, as of  `v3.7.3`. `"true"` or `"false"` are being converted to or just interpreted as booleans: 

```sh
<some path>/lua-language-server-3.7.3/bin/lua-language-server--check="true" --checklevel=Hint
The argument of CHECK must be a string, but got boolean
```

Any other, non-empty string seems to work fine:

```
<some path>/lua-language-server-3.7.3/bin/lua-language-server --check="yes" --checklevel=Hint
Diagnosis completed, no problems found
```

We can argue it's a bug (i didn't went as far as to attempt translation from Chinese: [https://github.com/sumneko/lua-language-server/issues/965](https://github.com/sumneko/lua-language-server/issues/965) :)), but i think meanwhile it would be useful to document current server's behavior. 