### PR TITLE
doc: point to renamed repo `schema.json`

### DIFF
--- a/src/content/wiki/configuration.mdx
+++ b/src/content/wiki/configuration.mdx
@@ -221,7 +221,7 @@ Here is a basic example of a `.luarc.json` file:
 
 ```JSON
 {
-  "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
   "workspace.library": ["path/to/library/directory"],
   "runtime.version": "Lua 5.3",
   "hint.enable": false


### PR DESCRIPTION
https://luals.github.io/wiki/configuration/ is currently referencing the recommended `$schema` value post repo rename

This PR updates the docs to point to the new org