### PR TITLE
Fix a typo in `@operator` example

### DIFF
--- a/src/content/wiki/annotations.mdx
+++ b/src/content/wiki/annotations.mdx
@@ -852,7 +852,7 @@ local v3 = v1 + v2
 
 ```Lua
 ---@class Passcode
----@operation unm:integer
+---@operator unm:integer
 
 ---@type Passcode
 local pA


### PR DESCRIPTION
Related: https://github.com/LuaLS/lua-language-server/pull/2772