### PR TITLE
docs: add missing diagnostics and settings.

### DIFF
--- a/src/content/wiki/diagnostics.mdx
+++ b/src/content/wiki/diagnostics.mdx
@@ -334,7 +334,7 @@ Triggered when there are two [`@param`](/wiki/annotations#param) annotations wit
 </Fragment>
 **Default File Status:** `"None"`
 
-Triggered when a functions signature is partially documented with [annotations](/wiki/annotations), but the annotations do not cover every element of the signature. 
+Triggered when a functions signature is partially documented with [annotations](/wiki/annotations), but the annotations do not cover every element of the signature.
 E.g. one of the parameters is not annotated, or the return value is not annotated.
 
 </Diagnostic>
@@ -465,6 +465,14 @@ Triggered when a variable has been marked as deprecated yet is still being used.
 ### discard-returns
 </Fragment>
 Triggered when the returns of a function are being ignored when it is not permitted. Functions can specify that their returns cannot be ignored with [`@nodiscard`](/wiki/annotations#nodiscard).
+
+</Diagnostic>
+
+<Diagnostic level="Warning">
+<Fragment slot="name">
+### invisible
+</Fragment>
+Triggered when accesses to fields which are invisible. Specifically, access to [`@package`](/wiki/annotations#package) from another file, [`@private`](/wiki/annotations#private) not within self class, or [`@protected`](/wiki/annotations#protected) not within self class or child classes.
 
 </Diagnostic>
 

--- a/src/content/wiki/diagnostics.mdx
+++ b/src/content/wiki/diagnostics.mdx
@@ -124,7 +124,7 @@ The codestyle group contains diagnostics for maintaining a good code style.
 </Fragment>
 **Default File Status:** `"None"`
 
-Triggered when the opinionated style checking detects an incorrectly styled line.
+Triggered when the opinionated style checking detects an incorrectly styled line. The style can be customized using the [`Lua.format.defaultConfig` setting](/wiki/settings#formatdefaultconfig).
 
 </Diagnostic>
 
@@ -134,7 +134,7 @@ Triggered when the opinionated style checking detects an incorrectly styled line
 </Fragment>
 **Default File Status:** `"None"`
 
-Triggered when the opinionated style checking detects an incorrectly named element.
+Triggered when the opinionated style checking detects an incorrectly named element. The style can be customized using the [`Lua.nameStyle.config` setting](/wiki/settings#namestyleconfig).
 
 </Diagnostic>
 
@@ -144,7 +144,7 @@ Triggered when the opinionated style checking detects an incorrectly named eleme
 </Fragment>
 **Default File Status:** `"None"`
 
-Triggered when a typo is detected in a string. The dictionary can be customized using the [`Lua.spell.dict` setting](https://github.com/LuaLS/lua-language-server/wiki/Settings#spelldict).
+Triggered when a typo is detected in a string. The dictionary can be customized using the [`Lua.spell.dict` setting](/wiki/settings#spelldict).
 
 </Diagnostic>
 

--- a/src/content/wiki/export-docs.mdx
+++ b/src/content/wiki/export-docs.mdx
@@ -266,3 +266,31 @@ import vscodeImg from "~/assets/images/vscode.svg"
 
    </div>
 </Tabs>
+
+## Custom
+
+By specifying [`Lua.docScriptPath` setting](/wiki/settings#docscriptpath), you could override the default documentation generation behavior. When set, the server uses this script (instead of [the built-in one](https://github.com/LuaLS/lua-language-server/blob/master/script/cli/doc/export.lua)) to generate LuaDocs, allowing customization of filtering, sorting, and formatting rules. Leave empty to use the default script. Requires the custom script to implement specific APIs for compatibility.
+
+<Accordion>
+
+    <span slot="summary">API</span>
+
+    ```Lua
+    export.getLocalPath(uri) -- Called when the documentation needs to get the path of a source relative to the DOC path. Returns the relative path, or the absolute path, prefixed with the string '[FOREIGN]'
+
+    export.positionOf(rowcol) -- Wrapper for guide.positionOf(rowcol[1], rowcol[2])
+
+    export.sortDoc(a,b) -- A comparison function used by table.sort that is used to sort every piece of documentation in alphabetical order.
+
+    export.documentObject(source, has_seen) -- A function that gets called on every source object. It is responsible for filtering each source to their corresponding export.makeDocObject[<TYPE>] function
+
+    export.makeDocObject[<TYPE>] -- A table of functions that are responsible for building their corresponding <TYPE>'s documentation. TYPES include 'type', 'variable', 'doc.class', etc. 'INIT' corresponds to every documentation object before it is processed by its corresponding type.
+
+    export.gatherGlobals() -- Called when the documentation needs an exhaustive list of the globals it should export documentation. By default this includes the result of vm.getAllGlobals(). Returns the collected variables/types.
+
+    export.makeDocs(globals, callback) -- Documents globals from export.gatherGlobals() by calling export.documentObject on each one; updates its progress by calling callback when a global is finished being documented. Returns a table of the collected documentation
+
+    export.serializeAndExport(docs, outputDir) -- Serializes documentation tables from export.makeDocs to json and markdown, Writes them to <outputDir>/doc.json and <outputDir>/doc.md, respectively. Returns these paths.
+    ```
+
+</Accordion>

--- a/src/content/wiki/settings.mdx
+++ b/src/content/wiki/settings.mdx
@@ -27,6 +27,31 @@ Settings that affect the [addon manager](/wiki/addons#addon-manager).
 
 Set the on/off state of the addon manager. Disabling the addon manager prevents it from registering its command.
 
+### addonManager.repositoryBranch
+
+**Type:** `string`<br/>
+**Default:** `""`
+
+Specifies the git branch used by the addon manager.
+
+### addonManager.repositoryPath
+
+**Type:** `string`<br/>
+**Default:** `""`
+
+Specifies the git path used by the addon manager.
+
+## codeLens
+
+Settings that affect the [codeLens](https://code.visualstudio.com/blogs/2017/02/12/code-lens-roundup).
+
+### codeLens.enable
+
+**Type:** `boolean`<br/>
+**Default:** `false`
+
+Enable code lens.
+
 ## completion
 
 Settings that adjust how autocompletions are provided while typing.
@@ -197,6 +222,13 @@ An array of variable names that will be declared as global.
   "diagnostics.globals": ["myGlobal"]
 }
 ```
+
+### diagnostics.globalsRegex
+
+**Type:** `Array<string>`<br/>
+**Default:** `[]`
+
+Find defined global variables using regex.
 
 ### diagnostics.groupFileStatus
 
@@ -695,13 +727,55 @@ The pattern used for matching table field names as a [private](/wiki/annotations
 
 The pattern used for matching field names as a [protected](/wiki/annotations#protected) field. Fields that match any of the patterns provided will be private to that class and its child classes.
 
+### doc.regengine
+
+**Type:** `string`<br/>
+**Default:** `"glob"`<br/>
+**Options:**
+
+- `"glob"` - The default lightweight pattern syntax
+- `"lua"` - Full Lua-style regular expressions
+
+Specifies the regular expression engine used for matching documentation scope names.
+
+## docScriptPath
+
+**Type:** `string`<br/>
+**Default:** `""`<br/>
+
+Specifies a custom Lua script path to override the default documentation generation behavior. When set, the server uses this script (instead of [the built-in one](https://github.com/LuaLS/lua-language-server/blob/master/script/cli/doc/export.lua)) to generate LuaDocs, allowing customization of filtering, sorting, and formatting rules. Leave empty to use the default script. Requires the custom script to implement specific APIs for compatibility.
+
+<Accordion>
+
+<span slot="summary">API</span>
+
+```Lua
+export.getLocalPath(uri) -- Called when the documentation needs to get the path of a source relative to the DOC path. Returns the relative path, or the absolute path, prefixed with the string '[FOREIGN]'
+
+export.positionOf(rowcol) -- Wrapper for guide.positionOf(rowcol[1], rowcol[2])
+
+export.sortDoc(a,b) -- A comparison function used by table.sort that is used to sort every piece of documentation in alphabetical order.
+
+export.documentObject(source, has_seen) -- A function that gets called on every source object. It is responsible for filtering each source to their corresponding export.makeDocObject[<TYPE>] function
+
+export.makeDocObject[<TYPE>] -- A table of functions that are responsible for building their corresponding <TYPE>'s documentation. TYPES include 'type', 'variable', 'doc.class', etc. 'INIT' corresponds to every documentation object before it is processed by its corresponding type.
+
+export.gatherGlobals() -- Called when the documentation needs an exhaustive list of the globals it should export documentation. By default this includes the result of vm.getAllGlobals(). Returns the collected variables/types.
+
+export.makeDocs(globals, callback) -- Documents globals from export.gatherGlobals() by calling export.documentObject on each one; updates its progress by calling callback when a global is finished being documented. Returns a table of the collected documentation
+
+export.serializeAndExport(docs, outputDir) -- Serializes documentation tables from export.makeDocs to json and markdown, Writes them to <outputDir>/doc.json and <outputDir>/doc.md, respectively. Returns these paths.
+```
+
+</Accordion>
+
 ## format
 
-Settings for configuring the built-in code formatter.
+Settings for configuring the [built-in code formatter](/wiki/formatter).
 
 ### format.defaultConfig
 
-**Type:** `Object<string, string`<br/>
+**Type:** `Object<string, string>`<br/>
 **Default:** `{}`
 
 The default configuration for the formatter. If there is a `.editorconfig` in the workspace, it will take priority. Read more on the [formatter's GitHub page](https://github.com/CppCXY/EmmyLuaCodeStyle/tree/master/docs).
@@ -735,6 +809,13 @@ Settings for configuring inline hints. See an example below.
 **Default:** `true`
 
 If a function has been defined as [`@async`](/wiki/annotations#async), display an `await` hint when it is being called.
+
+### hint.awaitPropagate
+
+**Type:** `boolean`<br/>
+**Default:** `false`
+
+Enable the propagation of `await`. When a function calls a function marked [`@async`](/wiki/annotations#async), it will be automatically marked as [`@async`](/wiki/annotations#async).
 
 ### hint.enable
 
@@ -783,7 +864,7 @@ Show a hint to display the type being applied at assignment operations.
 
 ## hover
 
-Setting for configuring hover tooltips. The hover tooltips can contain all kinds of useful information.
+Settings for configuring hover tooltips. The hover tooltips can contain all kinds of useful information.
 
 ### hover.enable
 
@@ -834,6 +915,24 @@ Enable hovering a string that contains an escape character to see its true strin
 
 The maximum number of characters that can be previewed by hovering a string before it is truncated.
 
+## language
+
+Settings for VSCode only.
+
+### language.completeAnnotation
+
+**Type:** `boolean`<br/>
+**Default:** `true`
+
+Automatically insert "---@ " after a line break following a annotation.
+
+### language.fixIndent
+
+**Type:** `boolean`<br/>
+**Default:** `true`
+
+Fix incorrect auto-indentation, such as incorrect indentation when line breaks occur within a string containing the word "function".
+
 ## misc
 
 Miscellaneous settings that do not belong to any of the other groups.
@@ -852,6 +951,17 @@ Miscellaneous settings that do not belong to any of the other groups.
 
 Manually specify the path for the Lua Language Server executable file.
 
+## nameStyle
+
+Settings for configuring [name style diagnostics](/wiki/diagnostics#name-style-check).
+
+### nameStyle.config
+
+**Type:** <code>Object&lt;string, case&gt;</code><br/>
+**Default:** `{}`
+
+Set name style config. Read more on the [formatter's GitHub page](https://github.com/CppCXY/EmmyLuaCodeStyle/tree/master/docs).
+
 ## runtime
 
 Settings for configuring the runtime environment.
@@ -862,7 +972,7 @@ Settings for configuring the runtime environment.
 
 **`status` Options:**
 
-- `"default"` - The library will be enabled if it is a part of the current [`runtime.version`](#runtimeversion).
+- `"default"` - The library will be enabled if it is a part of the current [`runtime.version`](#runtimeversion)
 - `"enable"` - Always enable this library
 - `"disable"` - Always disable this library
 
@@ -1050,7 +1160,7 @@ The spell group contains settings that help detect typos and misspellings.
 **Type:** `Array<string>`<br/>
 **Default:** `[]`
 
-A custom dictionary of words that you know are spelled correctly but are being reported as incorrect. Adding words to this dictionary will make them exempt from spell checking.
+A custom dictionary of words that you know are spelled correctly but are being reported as incorrect. Adding words to this dictionary will make them exempt from [spell checking](/wiki/diagnostics#spell-check).
 
 ## telemetry
 
@@ -1078,6 +1188,31 @@ The type group contains settings for type checking.
 **Default:** `false`
 
 Whether casting a `number` to an `integer` is allowed.
+
+### type.checkTableShape
+
+**Type:** `boolean`<br/>
+**Default:** `false`
+
+Strictly check the shape of the table.
+
+### type.inferParamType
+
+**Type:** `boolean`<br/>
+**Default:** `false`
+
+When a parameter type is not annotated, it is inferred from the function's call sites.
+
+When this setting is `false`, the type of the parameter is `any` when it is not annotated.
+
+### type.inferTableSize
+
+**Type:** `integer`<br/>
+**Default:** `10`
+
+Controls the maximum number of table fields analyzed during type inference. For tables with fields exceeding this value, only the first N fields (where N is this setting's value) are used to infer types, prioritizing analysis performance. Smaller tables will have all fields analyzed for higher type accuracy.
+
+Adjust this value to balance between precise type hints and efficient analysis, especially when working with large configuration tables or performance-sensitive projects.
 
 ### type.weakNilCheck
 
@@ -1108,6 +1243,41 @@ Whether it is permitted to assign a union type which only has one matching type 
 ---@type string
 local str = false
 ```
+
+## typeFormat
+
+The typeFormat group contains settings that configures the formatting behavior.
+
+### typeFormat.config
+
+**Type:** <code>Object&lt;behavior, boolean_string&gt;</code><br/>
+
+**`behavior` Options:**
+
+- `"auto_complete_end"` - Controls if `end` is automatically completed at suitable positions
+- `"auto_complete_table_sep"` - Controls if a separator is automatically appended at the end of a table declaration
+- `"format_line"` - Controls if a line is formatted at all
+
+**`boolean_string` Options:**
+
+- `"true"` - On
+- `"false"` - Off
+
+<Accordion>
+
+<span slot="summary">Default Value</span>
+
+```JSON
+{
+  "auto_complete_end": "true",
+  "auto_complete_table_sep": "true",
+  "format_line": "true"
+}
+```
+
+</Accordion>
+
+Configure the formatting behavior while typing Lua code.
 
 ## window
 

--- a/src/content/wiki/settings.mdx
+++ b/src/content/wiki/settings.mdx
@@ -230,6 +230,7 @@ An array of variable names that will be declared as global.
   "await": "Fallback",
   /*
    * codestyle-check
+   * name-style-check
    * spell-check
    */
   "codestyle": "Fallback",
@@ -246,12 +247,14 @@ An array of variable names that will be declared as global.
    */
   "global": "Fallback",
   /*
-   * cast-type-mismatch
    * circle-doc-class
    * doc-field-no-class
    * duplicate-doc-alias
    * duplicate-doc-field
    * duplicate-doc-param
+   * incomplete-signature-doc
+   * missing-global-doc
+   * missing-local-export-doc
    * undefined-doc-class
    * undefined-doc-name
    * undefined-doc-param
@@ -268,6 +271,7 @@ An array of variable names that will be declared as global.
    * close-non-object
    * deprecated
    * discard-returns
+   * invisible
    */
   "strict": "Fallback",
   /*
@@ -278,6 +282,7 @@ An array of variable names that will be declared as global.
    * assign-type-mismatch
    * cast-local-type
    * cast-type-mismatch
+   * inject-field
    * need-check-nil
    * param-type-mismatch
    * return-type-mismatch
@@ -285,6 +290,7 @@ An array of variable names that will be declared as global.
    */
   "type-check": "Fallback",
   /*
+   * missing-fields
    * missing-parameter
    * missing-return
    * missing-return-value
@@ -346,6 +352,7 @@ Set the file status required for each diagnostic group. This setting is an `Obje
   "await": "Fallback",
   /*
    * codestyle-check
+   * name-style-check
    * spell-check
    */
   "codestyle": "Fallback",
@@ -362,12 +369,14 @@ Set the file status required for each diagnostic group. This setting is an `Obje
    */
   "global": "Fallback",
   /*
-   * cast-type-mismatch
    * circle-doc-class
    * doc-field-no-class
    * duplicate-doc-alias
    * duplicate-doc-field
    * duplicate-doc-param
+   * incomplete-signature-doc
+   * missing-global-doc
+   * missing-local-export-doc
    * undefined-doc-class
    * undefined-doc-name
    * undefined-doc-param
@@ -384,6 +393,7 @@ Set the file status required for each diagnostic group. This setting is an `Obje
    * close-non-object
    * deprecated
    * discard-returns
+   * invisible
    */
   "strict": "Fallback",
   /*
@@ -394,6 +404,7 @@ Set the file status required for each diagnostic group. This setting is an `Obje
    * assign-type-mismatch
    * cast-local-type
    * cast-type-mismatch
+   * inject-field
    * need-check-nil
    * param-type-mismatch
    * return-type-mismatch
@@ -401,6 +412,7 @@ Set the file status required for each diagnostic group. This setting is an `Obje
    */
   "type-check": "Fallback",
   /*
+   * missing-fields
    * missing-parameter
    * missing-return
    * missing-return-value
@@ -488,13 +500,21 @@ Set how files loaded with [`workspace.library`](#workspacelibrary) are diagnosed
   "duplicate-doc-field": "Any",
   "duplicate-doc-param": "Any",
   "duplicate-index": "Any",
-  "duplicate-set-field": "Any",
+  "duplicate-set-field": "Opened",
   "empty-block": "Opened",
+  "global-elements": "None",
   "global-in-nil-env": "Any",
+  "incomplete-signature-doc": "None",
+  "inject-field": "Opened",
+  "invisible": "Any",
   "lowercase-global": "Any",
+  "missing-fields": "Any",
+  "missing-global-doc": "None",
+  "missing-local-export-doc": "None",
   "missing-parameter": "Any",
   "missing-return": "Any",
   "missing-return-value": "Any",
+  "name-style-check": "None",
   "need-check-nil": "Opened",
   "newfield-call": "Any",
   "newline-call": "Any",
@@ -570,11 +590,19 @@ Set how files loaded with [`workspace.library`](#workspacelibrary) are diagnosed
   "duplicate-index": "Warning",
   "duplicate-set-field": "Warning",
   "empty-block": "Hint",
+  "global-elements": "Warning",
   "global-in-nil-env": "Warning",
+  "incomplete-signature-doc": "Warning",
+  "inject-field": "Warning",
+  "invisible": "Warning",
   "lowercase-global": "Information",
+  "missing-fields": "Warning",
+  "missing-global-doc": "Warning",
+  "missing-local-export-doc": "Warning",
   "missing-parameter": "Warning",
   "missing-return": "Warning",
   "missing-return-value": "Warning",
+  "name-style-check": "Warning",
   "need-check-nil": "Warning",
   "newfield-call": "Warning",
   "newline-call": "Warning",

--- a/src/content/wiki/settings.mdx
+++ b/src/content/wiki/settings.mdx
@@ -743,29 +743,7 @@ Specifies the regular expression engine used for matching documentation scope na
 **Type:** `string`<br/>
 **Default:** `""`<br/>
 
-Specifies a custom Lua script path to override the default documentation generation behavior. When set, the server uses this script (instead of [the built-in one](https://github.com/LuaLS/lua-language-server/blob/master/script/cli/doc/export.lua)) to generate LuaDocs, allowing customization of filtering, sorting, and formatting rules. Leave empty to use the default script. Requires the custom script to implement specific APIs for compatibility.
-
-<Accordion>
-
-<span slot="summary">API</span>
-
-```Lua
-export.getLocalPath(uri) -- Called when the documentation needs to get the path of a source relative to the DOC path. Returns the relative path, or the absolute path, prefixed with the string '[FOREIGN]'
-
-export.positionOf(rowcol) -- Wrapper for guide.positionOf(rowcol[1], rowcol[2])
-
-export.sortDoc(a,b) -- A comparison function used by table.sort that is used to sort every piece of documentation in alphabetical order.
-
-export.documentObject(source, has_seen) -- A function that gets called on every source object. It is responsible for filtering each source to their corresponding export.makeDocObject[<TYPE>] function
-
-export.makeDocObject[<TYPE>] -- A table of functions that are responsible for building their corresponding <TYPE>'s documentation. TYPES include 'type', 'variable', 'doc.class', etc. 'INIT' corresponds to every documentation object before it is processed by its corresponding type.
-
-export.gatherGlobals() -- Called when the documentation needs an exhaustive list of the globals it should export documentation. By default this includes the result of vm.getAllGlobals(). Returns the collected variables/types.
-
-export.makeDocs(globals, callback) -- Documents globals from export.gatherGlobals() by calling export.documentObject on each one; updates its progress by calling callback when a global is finished being documented. Returns a table of the collected documentation
-
-export.serializeAndExport(docs, outputDir) -- Serializes documentation tables from export.makeDocs to json and markdown, Writes them to <outputDir>/doc.json and <outputDir>/doc.md, respectively. Returns these paths.
-```
+Specifies a custom Lua script path to [override the default documentation generation behavior](/wiki/export-docs#custom).
 
 </Accordion>
 


### PR DESCRIPTION
# List
1. Add `invisible` diagnostic.
2. Complete `diagnostics` setting.
3. Improve hyperlink in `format` setting.
4. Add `addonManager.repositoryBranch` setting.
5. Add `addonManager.repositoryPath` setting.
6. Add `codeLens` setting.
7. Add `diagnostics.globalsRegex` setting.
8. Add `doc.regengine` setting.
9. Add `docScriptPath` setting.
10. Add `hint.awaitPropagate` setting.
11. Add `language` setting.
12. Add `nameStyle` setting.
13. Add `type.checkTableShape` setting.
14. Add `type.inferParamType` setting.
15. Add `type.inferTableSize` setting.
16. Add `typeFormat` setting.
# 感想
解决一下文档残缺的历史遗留问题，真多呀……

花了一天时间肝出来的，可能会有笔误，敬请谅解！

另外，我尝试按照`README.md`进行部署，但是没有成功😟。因此所有的改动都未经测试，拜托请代为进行测试！